### PR TITLE
Define SVR4 for Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -O2
+CFLAGS = -O2 -DSVR4
 VERSION = 1.0.8
 
 TARGET = ttyrec ttyplay ttytime

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 CC = gcc
-CFLAGS = -O2 -DSVR4
+CFLAGS = -O2
+OS = $(shell uname -a)
+ifeq ($(findstring Ubuntu,$(OS)),Ubuntu)
+	CFLAGS += -DSVR4
+endif
+
 VERSION = 1.0.8
 
 TARGET = ttyrec ttyplay ttytime


### PR DESCRIPTION
If not define SVR4 on Ubuntu, it will return "Out of pty's". Ubuntu has no /dev/pty*.
