### PR TITLE
Build fixes for MacOS X

### DIFF
--- a/README
+++ b/README
@@ -8,6 +8,10 @@ or if your system is SVR4 system (Solaris etc.),
 
   % make CFLAGS=-DSVR4
 
+or if your system supports openpty(3) (MacOS X etc.),
+
+  % make CFLAGS=-DHAVE_openpty
+
 or if your system supports getpt(3),
 
   % make CFLAGS=-DHAVE_getpt

--- a/io.c
+++ b/io.c
@@ -158,4 +158,5 @@ efdopen (int fd, const char *mode)
 	fprintf(stderr, "%s: fdopen failed: %s\n", progname, strerror(errno));
 	exit(EXIT_FAILURE);
     }
+    return fp;
 }

--- a/io.h
+++ b/io.h
@@ -5,6 +5,7 @@
 
 int     read_header     (FILE *fp, Header *h);
 int     write_header    (FILE *fp, Header *h);
+void    set_progname    (const char *name);
 FILE*   efopen          (const char *path, const char *mode);
 int     edup            (int oldfd);
 int     edup2           (int oldfd, int newfd);

--- a/ttyrec.c
+++ b/ttyrec.c
@@ -71,7 +71,12 @@
 #define _(FOO) FOO
 
 #ifdef HAVE_openpty
+#if defined(__APPLE__)
+#include <util.h>
+#include <signal.h>
+#else
 #include <libutil.h>
+#endif
 #endif
 
 #if defined(SVR4) && !defined(CDEL)


### PR DESCRIPTION
Fixed libutil.h include error and several warnings on MacOS X
Added MacOS X build instructions to README
